### PR TITLE
Remove pipeline.validate() method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         java: [8]
         distribution: [temurin]
-        pdal: [2.6.2]
+        pdal: [2.6.3]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -79,7 +79,7 @@ jobs:
         os: [ubuntu-latest]
         java: [8]
         distribution: [temurin]
-        pdal: [2.6.2]
+        pdal: [2.6.3]
     runs-on: ${{ matrix.os }}
     if: github.event_name != 'pull_request'
     needs: [build]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.7.17
+version = 3.8.0
 runner.dialect = scala3
 align.openParenCallSite = true
 align.openParenDefnSite = true

--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ val json =
   """.stripMargin
 
 val pipeline = Pipeline(json, LogLevel.Debug5) // initialize and make it really noisy
-pipeline.validate() // check if our JSON and options were good
+
 pipeline.execute() // execute the pipeline
+
 val metadata = pipeline.getMetadata() // retrieve metadata
 val pvs      = pipeline.getPointViews() // iterator over PointViews
 val pv       = pvs.next() // let's take the first PointView

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 name := "pdal-jni"
 
-val scala212 = "2.12.18"
-val scala213 = "2.13.12"
-val scala3 = "3.3.1"
+val scala212 = "2.12.19"
+val scala213 = "2.13.13"
+val scala3 = "3.4.0"
 val scalaVersions = Seq(scala3, scala213, scala212)
 
 lazy val commonSettings = Seq(

--- a/core-scala/src/test/scala/io/pdal/pipeline/PipelineExpressionsSpec.scala
+++ b/core-scala/src/test/scala/io/pdal/pipeline/PipelineExpressionsSpec.scala
@@ -96,7 +96,6 @@ class PipelineExpressionsSpec extends AnyFunSpec with Matchers with BeforeAndAft
           FilterReprojection(outSrs = "EPSG:3857")
 
       val pipeline = expression.toPipeline
-      pipeline.validate() shouldBe true
       pipeline.execute()
       pipeline.close()
     }

--- a/core/src/main/scala/io/pdal/Pipeline.scala
+++ b/core/src/main/scala/io/pdal/Pipeline.scala
@@ -40,7 +40,6 @@ class Pipeline private (val json: String, val logLevel: Int) extends Native {
   @native def getMetadata(): String
   @native def getSchema(): String
   @native def getQuickInfo(): String
-  @native def validate(): Boolean
   @native private def getLogLevelInt(): Int
 
   def getLogLevel(): LogLevel.Value = LogLevel.apply(getLogLevelInt())

--- a/core/src/test/resources/metadata.json
+++ b/core/src/test/resources/metadata.json
@@ -1,37 +1,176 @@
 {
   "metadata": {
-    "readers.las": [
-      {
-        "compressed": false,
-        "copc": false,
-        "count": 1065,
-        "creation_doy": 0,
-        "creation_year": 0,
-        "dataformat_id": 3,
-        "dataoffset": 229,
-        "filesource_id": 0,
-        "global_encoding": 0,
-        "global_encoding_base64": "AAA=",
-        "header_size": 227,
-        "major_version": 1,
-        "maxx": 638982.55,
-        "maxy": 853535.43,
-        "maxz": 586.38,
-        "minor_version": 2,
-        "minx": 635619.85,
-        "miny": 848899.7,
-        "minz": 406.59,
-        "offset_x": 0,
-        "offset_y": 0,
-        "offset_z": 0,
-        "point_length": 34,
-        "project_id": "00000000-0000-0000-0000-000000000000",
-        "scale_x": 0.01,
-        "scale_y": 0.01,
-        "scale_z": 0.01,
-        "software_id": "TerraScan",
-        "system_id": ""
-      }
-    ]
+    "readers.las": {
+      "comp_spatialreference": "PROJCS[\"NAD83(HARN) / Oregon LCC (m)\",GEOGCS[\"NAD83(HARN)\",DATUM[\"NAD83_High_Accuracy_Reference_Network\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6152\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4152\"]],PROJECTION[\"Lambert_Conformal_Conic_2SP\"],PARAMETER[\"latitude_of_origin\",41.75],PARAMETER[\"central_meridian\",-120.5],PARAMETER[\"standard_parallel_1\",43],PARAMETER[\"standard_parallel_2\",45.5],PARAMETER[\"false_easting\",400000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"2993\"]]",
+      "compressed": false,
+      "copc": false,
+      "count": 1065,
+      "creation_doy": 0,
+      "creation_year": 0,
+      "dataformat_id": 3,
+      "dataoffset": 229,
+      "filesource_id": 0,
+      "global_encoding": 0,
+      "global_encoding_base64": "AAA=",
+      "header_size": 227,
+      "major_version": 1,
+      "maxx": 638982.55,
+      "maxy": 853535.43,
+      "maxz": 586.38,
+      "minor_version": 2,
+      "minx": 635619.85,
+      "miny": 848899.7,
+      "minz": 406.59,
+      "offset_x": 0,
+      "offset_y": 0,
+      "offset_z": 0,
+      "point_length": 34,
+      "project_id": "00000000-0000-0000-0000-000000000000",
+      "scale_x": 0.01,
+      "scale_y": 0.01,
+      "scale_z": 0.01,
+      "software_id": "TerraScan",
+      "spatialreference": "PROJCS[\"NAD83(HARN) / Oregon LCC (m)\",GEOGCS[\"NAD83(HARN)\",DATUM[\"NAD83_High_Accuracy_Reference_Network\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6152\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4152\"]],PROJECTION[\"Lambert_Conformal_Conic_2SP\"],PARAMETER[\"latitude_of_origin\",41.75],PARAMETER[\"central_meridian\",-120.5],PARAMETER[\"standard_parallel_1\",43],PARAMETER[\"standard_parallel_2\",45.5],PARAMETER[\"false_easting\",400000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"2993\"]]",
+      "srs": {
+        "compoundwkt": "PROJCS[\"NAD83(HARN) / Oregon LCC (m)\",GEOGCS[\"NAD83(HARN)\",DATUM[\"NAD83_High_Accuracy_Reference_Network\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6152\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4152\"]],PROJECTION[\"Lambert_Conformal_Conic_2SP\"],PARAMETER[\"latitude_of_origin\",41.75],PARAMETER[\"central_meridian\",-120.5],PARAMETER[\"standard_parallel_1\",43],PARAMETER[\"standard_parallel_2\",45.5],PARAMETER[\"false_easting\",400000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"2993\"]]",
+        "horizontal": "PROJCS[\"NAD83(HARN) / Oregon LCC (m)\",GEOGCS[\"NAD83(HARN)\",DATUM[\"NAD83_High_Accuracy_Reference_Network\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6152\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4152\"]],PROJECTION[\"Lambert_Conformal_Conic_2SP\"],PARAMETER[\"latitude_of_origin\",41.75],PARAMETER[\"central_meridian\",-120.5],PARAMETER[\"standard_parallel_1\",43],PARAMETER[\"standard_parallel_2\",45.5],PARAMETER[\"false_easting\",400000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"2993\"]]",
+        "isgeocentric": false,
+        "isgeographic": false,
+        "json": {
+          "type": "ProjectedCRS",
+          "name": "NAD83(HARN) / Oregon LCC (m)",
+          "base_crs": {
+            "name": "NAD83(HARN)",
+            "datum": {
+              "type": "GeodeticReferenceFrame",
+              "name": "NAD83 (High Accuracy Reference Network)",
+              "ellipsoid": {
+                "name": "GRS 1980",
+                "semi_major_axis": 6378137,
+                "inverse_flattening": 298.257222101
+              }
+            },
+            "coordinate_system": {
+              "subtype": "ellipsoidal",
+              "axis": [
+                {
+                  "name": "Geodetic latitude",
+                  "abbreviation": "Lat",
+                  "direction": "north",
+                  "unit": "degree"
+                },
+                {
+                  "name": "Geodetic longitude",
+                  "abbreviation": "Lon",
+                  "direction": "east",
+                  "unit": "degree"
+                }
+              ]
+            },
+            "id": {
+              "authority": "EPSG",
+              "code": 4152
+            }
+          },
+          "conversion": {
+            "name": "unnamed",
+            "method": {
+              "name": "Lambert Conic Conformal (2SP)",
+              "id": {
+                "authority": "EPSG",
+                "code": 9802
+              }
+            },
+            "parameters": [
+              {
+                "name": "Latitude of false origin",
+                "value": 41.75,
+                "unit": "degree",
+                "id": {
+                  "authority": "EPSG",
+                  "code": 8821
+                }
+              },
+              {
+                "name": "Longitude of false origin",
+                "value": -120.5,
+                "unit": "degree",
+                "id": {
+                  "authority": "EPSG",
+                  "code": 8822
+                }
+              },
+              {
+                "name": "Latitude of 1st standard parallel",
+                "value": 43,
+                "unit": "degree",
+                "id": {
+                  "authority": "EPSG",
+                  "code": 8823
+                }
+              },
+              {
+                "name": "Latitude of 2nd standard parallel",
+                "value": 45.5,
+                "unit": "degree",
+                "id": {
+                  "authority": "EPSG",
+                  "code": 8824
+                }
+              },
+              {
+                "name": "Easting at false origin",
+                "value": 400000,
+                "unit": "metre",
+                "id": {
+                  "authority": "EPSG",
+                  "code": 8826
+                }
+              },
+              {
+                "name": "Northing at false origin",
+                "value": 0,
+                "unit": "metre",
+                "id": {
+                  "authority": "EPSG",
+                  "code": 8827
+                }
+              }
+            ]
+          },
+          "coordinate_system": {
+            "subtype": "Cartesian",
+            "axis": [
+              {
+                "name": "Easting",
+                "abbreviation": "",
+                "direction": "east",
+                "unit": "metre"
+              },
+              {
+                "name": "Northing",
+                "abbreviation": "",
+                "direction": "north",
+                "unit": "metre"
+              }
+            ]
+          },
+          "id": {
+            "authority": "EPSG",
+            "code": 2993
+          }
+        },
+        "prettycompoundwkt": "PROJCS[\"NAD83(HARN) / Oregon LCC (m)\",\n    GEOGCS[\"NAD83(HARN)\",\n        DATUM[\"NAD83_High_Accuracy_Reference_Network\",\n            SPHEROID[\"GRS 1980\",6378137,298.257222101,\n                AUTHORITY[\"EPSG\",\"7019\"]],\n            AUTHORITY[\"EPSG\",\"6152\"]],\n        PRIMEM[\"Greenwich\",0,\n            AUTHORITY[\"EPSG\",\"8901\"]],\n        UNIT[\"degree\",0.0174532925199433,\n            AUTHORITY[\"EPSG\",\"9122\"]],\n        AUTHORITY[\"EPSG\",\"4152\"]],\n    PROJECTION[\"Lambert_Conformal_Conic_2SP\"],\n    PARAMETER[\"latitude_of_origin\",41.75],\n    PARAMETER[\"central_meridian\",-120.5],\n    PARAMETER[\"standard_parallel_1\",43],\n    PARAMETER[\"standard_parallel_2\",45.5],\n    PARAMETER[\"false_easting\",400000],\n    PARAMETER[\"false_northing\",0],\n    UNIT[\"metre\",1,\n        AUTHORITY[\"EPSG\",\"9001\"]],\n    AXIS[\"Easting\",EAST],\n    AXIS[\"Northing\",NORTH],\n    AUTHORITY[\"EPSG\",\"2993\"]]",
+        "prettywkt": "PROJCS[\"NAD83(HARN) / Oregon LCC (m)\",\n    GEOGCS[\"NAD83(HARN)\",\n        DATUM[\"NAD83_High_Accuracy_Reference_Network\",\n            SPHEROID[\"GRS 1980\",6378137,298.257222101,\n                AUTHORITY[\"EPSG\",\"7019\"]],\n            AUTHORITY[\"EPSG\",\"6152\"]],\n        PRIMEM[\"Greenwich\",0,\n            AUTHORITY[\"EPSG\",\"8901\"]],\n        UNIT[\"degree\",0.0174532925199433,\n            AUTHORITY[\"EPSG\",\"9122\"]],\n        AUTHORITY[\"EPSG\",\"4152\"]],\n    PROJECTION[\"Lambert_Conformal_Conic_2SP\"],\n    PARAMETER[\"latitude_of_origin\",41.75],\n    PARAMETER[\"central_meridian\",-120.5],\n    PARAMETER[\"standard_parallel_1\",43],\n    PARAMETER[\"standard_parallel_2\",45.5],\n    PARAMETER[\"false_easting\",400000],\n    PARAMETER[\"false_northing\",0],\n    UNIT[\"metre\",1,\n        AUTHORITY[\"EPSG\",\"9001\"]],\n    AXIS[\"Easting\",EAST],\n    AXIS[\"Northing\",NORTH],\n    AUTHORITY[\"EPSG\",\"2993\"]]",
+        "proj4": "+proj=lcc +lat_0=41.75 +lon_0=-120.5 +lat_1=43 +lat_2=45.5 +x_0=400000 +y_0=0 +ellps=GRS80 +units=m +no_defs",
+        "units": {
+          "horizontal": "metre",
+          "vertical": ""
+        },
+        "vertical": "",
+        "wkt": "PROJCS[\"NAD83(HARN) / Oregon LCC (m)\",GEOGCS[\"NAD83(HARN)\",DATUM[\"NAD83_High_Accuracy_Reference_Network\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6152\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4152\"]],PROJECTION[\"Lambert_Conformal_Conic_2SP\"],PARAMETER[\"latitude_of_origin\",41.75],PARAMETER[\"central_meridian\",-120.5],PARAMETER[\"standard_parallel_1\",43],PARAMETER[\"standard_parallel_2\",45.5],PARAMETER[\"false_easting\",400000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"2993\"]]"
+      },
+      "system_id": ""
+    }
   }
 }

--- a/core/src/test/scala/io/pdal/PipelineSpec.scala
+++ b/core/src/test/scala/io/pdal/PipelineSpec.scala
@@ -31,15 +31,14 @@ import scala.collection.JavaConverters._
 
 class PipelineSpec extends TestEnvironmentSpec {
   describe("Pipeline execution") {
-    it("should validate as incorrect json (bad json passed)") {
+    it("should throw ExecutionException when bad pipeline json passed into the constructor") {
       val badPipeline = Pipeline(badJson)
-      badPipeline.validate() should be(false)
+      val exception = intercept[ExecutionException](badPipeline.execute())
+      exception.getMessage should include(
+        "Unable to open stream for 'nofile.las' with error 'No such file or directory'"
+      )
       badPipeline.close()
       badPipeline.ptr() should be(0)
-    }
-
-    it("should validate json") {
-      pipeline.validate() should be(true)
     }
 
     it("should execute pipeline") {
@@ -203,7 +202,6 @@ class PipelineSpec extends TestEnvironmentSpec {
     }
 
     it("should extract mesh in iterative fashion") {
-      pipelineDelaunay.validate() should be(true)
       pipelineDelaunay.execute()
       val pvi = pipelineDelaunay.getPointViews()
       val pv = pvi.next()

--- a/native/src/JavaPipeline.cpp
+++ b/native/src/JavaPipeline.cpp
@@ -67,13 +67,6 @@ PipelineExecutor::PipelineExecutor(string const& json, int level)
     m_manager.readPipeline(strm);
 }
 
-bool PipelineExecutor::validate()
-{
-    m_manager.prepare();
-
-    return true;
-}
-
 point_count_t PipelineExecutor::execute()
 {
 

--- a/native/src/include/JavaPipeline.hpp
+++ b/native/src/include/JavaPipeline.hpp
@@ -62,7 +62,6 @@ public:
     PipelineExecutor(std::string const& json, int level);
     virtual ~PipelineExecutor() = default;
 
-    bool validate();
     point_count_t execute();
     point_count_t executeStream(point_count_t streamLimit);
 

--- a/native/src/include/io_pdal_Pipeline.h
+++ b/native/src/include/io_pdal_Pipeline.h
@@ -81,14 +81,6 @@ JNIEXPORT jstring JNICALL Java_io_pdal_Pipeline_getQuickInfo
 
 /*
  * Class:      io_pdal_Pipeline
- * Method:     validate
- * Signature:  ()Z
- */
-JNIEXPORT jboolean JNICALL Java_io_pdal_Pipeline_validate
-  (JNIEnv *, jobject);
-
-/*
- * Class:      io_pdal_Pipeline
  * Method:     getLogLevelInt
  * Signature:  ()I
  */

--- a/native/src/io_pdal_Pipeline.cpp
+++ b/native/src/io_pdal_Pipeline.cpp
@@ -173,24 +173,6 @@ JNIEXPORT jstring JNICALL Java_io_pdal_Pipeline_getQuickInfo
     }
 }
 
-JNIEXPORT jboolean JNICALL Java_io_pdal_Pipeline_validate
-  (JNIEnv *env, jobject obj)
-{
-    PipelineExecutor *p = getHandle<PipelineExecutor>(env, obj);
-    bool result;
-    try
-    {
-        result = p->validate();
-    }
-    catch(const pdal_error& pe)
-    {
-        std::cerr << "Runtime error: " << pe.what() << std::endl;
-        result = false;
-    }
-
-    return result;
-}
-
 JNIEXPORT jint JNICALL Java_io_pdal_Pipeline_getLogLevelInt
   (JNIEnv *env, jobject obj)
 {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{headerLicense, heade
 
 object Version {
   val jts = "1.19.0"
-  val scalaTest = "3.2.17"
+  val scalaTest = "3.2.18"
   val circe = "0.14.6"
   val circeExtras = "0.14.3"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.9


### PR DESCRIPTION
This PR drops `validated()` method since it may cause issues with some of the pipeline stages. 

Closes #85 