### PR TITLE
Adding MacOS M1 support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches: ['main']
     tags: [v*]
+  workflow_dispatch:
+
   # release:
     # types: [published]
 
@@ -13,8 +15,14 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        java: [8]
+        # Specifying `macos-14` is the way to get aarch64
+        os: [ubuntu-latest, macos-12, macos-14]
+        include:
+          - os: macos-12
+            arch: x86_64
+          - os: macos-14
+            arch: arm64
+        java: [11]
         distribution: [temurin]
         pdal: [2.6.3]
     runs-on: ${{ matrix.os }}
@@ -31,6 +39,9 @@ jobs:
         with:
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
+
+      - run: brew install sbt
+        if: ${{ matrix.os == 'macos-14' }}
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
@@ -70,8 +81,8 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ startsWith(matrix.os, 'macos') }}
         with:
-          name: macos
-          path: native/target/native/x86_64-darwin/bin
+          name: ${{ matrix.os }}
+          path: native/target/native/${{ matrix.arch }}-darwin/bin
 
   publish:
     strategy:
@@ -131,8 +142,12 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: macos
+          name: macos-12
           path: native/target/native/x86_64-darwin/bin
+      - uses: actions/download-artifact@v4
+        with:
+          name: macos-14
+          path: native/target/native/arm64-darwin/bin
 
       - name: Release
         run: sbt ci-release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+- Added Apple Silicon (ARM 64) to native build [#89](https://github.com/PDAL/java/pull/89) (@metasim)
+
 ## [2.6.2] - 2024-03-02
 ## Changed
 - Remove pipeline.validate() method [#86](https://github.com/pdal/java/pull/86) (@pomadchin)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It is released independently from PDAL itself as of PDAL 1.7.
 
 ## Usage 
 You can use `pdal-native` dep published into maven central in case you don't have installed JNI bindings and to avoid steps described below.
-Dependency contains bindings for `x86_64-darwin` and `x86_64-linux`, other versions are not supported yet.
+Dependency contains bindings for `x86_64-darwin`, `arm64-darwin`, and `x86_64-linux`, other versions are not supported yet.
 
 ### Versioning scheme
 
@@ -240,9 +240,6 @@ sbt
 # Java side development without binaries build
 PDAL_DEPEND_ON_NATIVE=false sbt -Djava.library.path=<path>
 ```
-#### Mac-OS ARM 
-Natives for arm64 are still not pre-built. If you need to get them, follow the guide above for a self build and finally go to `../pdal-java/native/target/`, here you will find the built `pdal-native.jar`. If you want to use it in a Java project, for example, you can go to `./m2/repository/io/pdal/pdal-native/<your-version>/` and replace the one taken from Maven with the one you have just built.
-
 ## Possible issues and solutions
 
 #### - In case of not installed as global PDAL change [this](./java/native/src/CMakeLists.txt#L25) line to:


### PR DESCRIPTION
This adds building `libpdaljni.dylib` for arm64 architectures.

I have successfully tested this up to the `publish` workflow:

https://github.com/s22s/PDAL-Java/actions/runs/8282743168

...but I need advice on how to test that stage.

Closes https://github.com/PDAL/java/issues/61
