### PR TITLE
Call initialize in the Pipeline public constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ String json =
 
 var pipeline = new Pipeline(json, LogLevel.Error());
 
-pipeline.initialize(); // initialize the pipeline
 pipeline.execute(); // execute the pipeline
 
 var metadata = pipeline.getMetadata(); // retrieve metadata

--- a/core/src/main/scala/io/pdal/Pipeline.scala
+++ b/core/src/main/scala/io/pdal/Pipeline.scala
@@ -33,7 +33,7 @@ class Pipeline private (val json: String, val logLevel: Int) extends Native {
     this(json, logLevel.id); initialize()
   }
 
-  @native def initialize(): Unit
+  @native private def initialize(): Unit
   @native def execute(): Unit
   @native def getPointViews(): PointViewIterator
   @native def close(): Unit

--- a/core/src/main/scala/io/pdal/Pipeline.scala
+++ b/core/src/main/scala/io/pdal/Pipeline.scala
@@ -29,7 +29,9 @@ import com.github.sbt.jni.syntax.NativeLoader
 class Pipeline private (val json: String, val logLevel: Int) extends Native {
   Pipeline // reference companion object so nativeLoader loads the JNI native libraries
 
-  def this(json: String, logLevel: LogLevel.Value = LogLevel.Error) = this(json, logLevel.id)
+  def this(json: String, logLevel: LogLevel.Value = LogLevel.Error) = {
+    this(json, logLevel.id); initialize()
+  }
 
   @native def initialize(): Unit
   @native def execute(): Unit
@@ -46,7 +48,6 @@ class Pipeline private (val json: String, val logLevel: Int) extends Native {
 }
 
 object Pipeline extends NativeLoader("pdaljni.2.6") {
-  def apply(json: String, logLevel: LogLevel.Value = LogLevel.Error): Pipeline = {
-    val p = new Pipeline(json, logLevel); p.initialize(); p
-  }
+  def apply(json: String, logLevel: LogLevel.Value = LogLevel.Error): Pipeline =
+    new Pipeline(json, logLevel)
 }


### PR DESCRIPTION
This PR makes initialization a part of an aux constructor. There are also no reasons in using pipeline without initialization.