### PR TITLE
Upd PDAL up to 2.7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
             arch: arm64
         java: [11]
         distribution: [temurin]
-        pdal: [2.7.0]
+        pdal: [2.7.1]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -91,7 +91,7 @@ jobs:
         os: [ubuntu-latest]
         java: [8]
         distribution: [temurin]
-        pdal: [2.7.0]
+        pdal: [2.7.1]
     runs-on: ${{ matrix.os }}
     if: github.event_name != 'pull_request'
     needs: [build]


### PR DESCRIPTION
PR Updates PDAL version used to build binaries in CI.