### PR TITLE
PDAL 2.8.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
             arch: arm64
         java: [11]
         distribution: [temurin]
-        pdal: [2.7.1]
+        pdal: [2.8.0]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -91,7 +91,7 @@ jobs:
         os: [ubuntu-latest]
         java: [11]
         distribution: [temurin]
-        pdal: [2.7.1]
+        pdal: [2.8.0]
     runs-on: ${{ matrix.os }}
     if: github.event_name != 'pull_request'
     needs: [build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install PDAL
         if: steps.conda-cache.outputs.cache-hit != 'true'
-        run: conda install libpdal=${{ matrix.pdal }}
+        run: conda install libpdal-trajectory=${{ matrix.pdal }} libpdal=${{ matrix.pdal }}
 
       - name: Set LD_LIBRARY_PATH
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -136,7 +136,7 @@ jobs:
 
       - name: Install PDAL
         if: steps.conda-cache.outputs.cache-hit != 'true'
-        run: conda install libpdal=${{ matrix.pdal }}
+        run: conda install libpdal-trajectory=${{ matrix.pdal }} libpdal=${{ matrix.pdal }}
 
       - name: Set LD_LIBRARY_PATH
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - run: brew install sbt
+        if: ${{ matrix.os == 'macos-latest' }}
 
       - uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       matrix:
         # Specifying `macos-14` is the way to get aarch64
-        os: [ubuntu-latest, macos-12, macos-14]
+        os: [ubuntu-latest, macos-13, macos-14]
         include:
-          - os: macos-12
+          - os: macos-13
             arch: x86_64
           - os: macos-14
             arch: arm64
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install PDAL
         if: steps.conda-cache.outputs.cache-hit != 'true'
-        run: conda install libpdal-trajectory=${{ matrix.pdal }} libpdal=${{ matrix.pdal }}
+        run: conda install libpdal=${{ matrix.pdal }}
 
       - name: Set LD_LIBRARY_PATH
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -136,7 +136,7 @@ jobs:
 
       - name: Install PDAL
         if: steps.conda-cache.outputs.cache-hit != 'true'
-        run: conda install libpdal-trajectory=${{ matrix.pdal }} libpdal=${{ matrix.pdal }}
+        run: conda install libpdal=${{ matrix.pdal }}
 
       - name: Set LD_LIBRARY_PATH
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -144,7 +144,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: macos-12
+          name: macos-13
           path: native/target/native/x86_64-darwin/bin
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,9 @@ jobs:
   build:
     strategy:
       matrix:
-        # Specifying `macos-14` is the way to get aarch64
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [ubuntu-latest, macos-latest]
         include:
-          - os: macos-13
-            arch: x86_64
-          - os: macos-14
+          - os: macos-latest
             arch: arm64
         java: [11]
         distribution: [temurin]
@@ -41,7 +38,6 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - run: brew install sbt
-        if: ${{ matrix.os == 'macos-14' }}
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
@@ -144,11 +140,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: macos-13
-          path: native/target/native/x86_64-darwin/bin
-      - uses: actions/download-artifact@v4
-        with:
-          name: macos-14
+          name: macos-latest
           path: native/target/native/arm64-darwin/bin
 
       - name: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install PDAL
         if: steps.conda-cache.outputs.cache-hit != 'true'
-        run: conda install libpdal=${{ matrix.pdal }}
+        run: conda install libpdal-core=${{ matrix.pdal }}
 
       - name: Set LD_LIBRARY_PATH
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -136,7 +136,7 @@ jobs:
 
       - name: Install PDAL
         if: steps.conda-cache.outputs.cache-hit != 'true'
-        run: conda install libpdal=${{ matrix.pdal }}
+        run: conda install libpdal-core=${{ matrix.pdal }}
 
       - name: Set LD_LIBRARY_PATH
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install PDAL
         if: steps.conda-cache.outputs.cache-hit != 'true'
-        run: conda install pdal=${{ matrix.pdal }}
+        run: conda install libpdal=${{ matrix.pdal }}
 
       - name: Set LD_LIBRARY_PATH
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -136,7 +136,7 @@ jobs:
 
       - name: Install PDAL
         if: steps.conda-cache.outputs.cache-hit != 'true'
-        run: conda install pdal=${{ matrix.pdal }}
+        run: conda install libpdal=${{ matrix.pdal }}
 
       - name: Set LD_LIBRARY_PATH
         if: ${{ matrix.os == 'ubuntu-latest' }}


### PR DESCRIPTION
Build against PDAL 2.8.0, this PR aligns our builds with https://github.com/PDAL/PDAL/blob/master/.github/workflows/osx.yml and we drop x64 PDAL MacOS builds.

Conda package got changed: 
* https://quansight.com/post/introducing-lightweight-versions-of-gdal-and-pdal/ 
* https://github.com/PDAL/PDAL/issues/4492#issuecomment-2339196888
