### PR TITLE
Update SBT and plugins, prepare for the central migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         os: [ubuntu-latest]
         java: [11]
         distribution: [temurin]
-        pdal: [2.8.1]
+        pdal: [2.8.4]
     runs-on: ${{ matrix.os }}
     if: github.event_name != 'pull_request'
     needs: [build]

--- a/HOWTORELEASE.txt
+++ b/HOWTORELEASE.txt
@@ -15,7 +15,8 @@ Release Process
 
 1) Publish JNI Bindings
     What you need:
-        - an account on sonatype (https://issues.sonatype.org/secure/Signup!default.jspa)
+        - (new) an account on central (https://central.sonatype.com/publishing/deployments)
+        - (old) an account on sonatype (https://issues.sonatype.org/secure/Signup!default.jspa)
         - ~/.sbt/1.0/sonatype.sbt file with the following content:
             credentials += Credentials("Sonatype Nexus Repository Manager",
                            "oss.sonatype.org",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDAL Java Bindings
 
-[![CI](https://github.com/PDAL/java/workflows/CI/badge.svg)](https://github.com/PDAL/java/actions) [![Join the chat at https://gitter.im/PDAL/PDAL](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/PDAL/PDAL?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Maven Central](https://img.shields.io/maven-central/v/io.pdal/pdal_2.13)](https://search.maven.org/search?q=g:io.pdal) [![Snapshots](https://img.shields.io/nexus/s/https/oss.sonatype.org/io.pdal/pdal_2.13)](https://oss.sonatype.org/content/repositories/snapshots/io/pdal/)
+[![CI](https://github.com/PDAL/java/workflows/CI/badge.svg)](https://github.com/PDAL/java/actions) [![Join the chat at https://gitter.im/PDAL/PDAL](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/PDAL/PDAL?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Maven Central](https://img.shields.io/maven-central/v/io.pdal/pdal_2.13)](https://search.maven.org/search?q=g:io.pdal) [![Snapshots Badge](https://img.shields.io/badge/snapshots-available-orange)](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/io.pdal/) 
 
 
 Java bindings to use PDAL on JVM (supports PDAL >= 2.0). macOS users can experience some issues with bindings that were build against a different PDAL version, so try to use a consistent PDAL version. 

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 name := "pdal-jni"
 
-val scala212 = "2.12.19"
-val scala213 = "2.13.15"
-val scala3 = "3.5.0"
+val scala212 = "2.12.20"
+val scala213 = "2.13.16"
+val scala3 = "3.7.1"
 val scalaVersions = Seq(scala3, scala213, scala212)
 
 lazy val commonSettings = Seq(

--- a/examples/pdal-jni/build.sbt
+++ b/examples/pdal-jni/build.sbt
@@ -1,6 +1,6 @@
-val scala212 = "2.12.19"
-val scala213 = "2.13.15"
-val scala3   = "3.5.0"
+val scala212 = "2.12.20"
+val scala213 = "2.13.16"
+val scala3   = "3.7.1"
 val scalaVersions = Seq(scala3, scala213, scala212)
 
 name := "pdal-jni"

--- a/examples/pdal-jni/project/build.properties
+++ b/examples/pdal-jni/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.2
+sbt.version=1.11.2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{headerLicense, heade
 object Version {
   val jts = "1.20.0"
   val scalaTest = "3.2.19"
-  val circe = "0.14.10"
+  val circe = "0.14.14"
   val circeExtras = "0.14.4"
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.3
+sbt.version=1.11.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.github.sbt" % "sbt-jni" % "1.7.0")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.4")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")


### PR DESCRIPTION
This PR updated dependencies and sbt version. This is a part of the migration to central.